### PR TITLE
Add slider ranges

### DIFF
--- a/src/main/java/bep/hax/modules/DiscordNotifs.java
+++ b/src/main/java/bep/hax/modules/DiscordNotifs.java
@@ -31,6 +31,7 @@ public class DiscordNotifs extends Module
         .name("message-delay")
         .description("The delay between messages in milliseconds.")
         .defaultValue(2000)
+        .sliderRange(0, 10000)
         .build()
     );
     private final Setting<Boolean> queueMessages = sgGeneral.add(new BoolSetting.Builder()

--- a/src/main/java/bep/hax/modules/ElytraFlyPlusPlus.java
+++ b/src/main/java/bep/hax/modules/ElytraFlyPlusPlus.java
@@ -140,6 +140,7 @@ public class ElytraFlyPlusPlus extends Module {
         .name("distance")
         .description("The distance to set the baritone goal for path realignment.")
         .defaultValue(10.0)
+        .sliderRange(0, 10)
         .visible(() -> bounce.get() && highwayObstaclePasser.get())
         .build()
     );
@@ -147,6 +148,8 @@ public class ElytraFlyPlusPlus extends Module {
         .name("y-level")
         .description("The Y level to bounce at. This must be correct or bounce will not start properly.")
         .defaultValue(120)
+        .range(-64, 320)
+        .sliderRange(-64, 320)
         .visible(() -> bounce.get() && highwayObstaclePasser.get())
         .build()
     );

--- a/src/main/java/bep/hax/modules/GrimAirPlace.java
+++ b/src/main/java/bep/hax/modules/GrimAirPlace.java
@@ -22,6 +22,7 @@ public class GrimAirPlace extends Module {
         .name("place-delay")
         .description("The delay in ticks between block placements.")
         .defaultValue(0)
+        .sliderRange(0, 10)
         .build()
     );
     private final Setting<Boolean> render = sgGeneral.add(new BoolSetting.Builder()


### PR DESCRIPTION
A few settings didn’t specify slider bounds, so they fell back to Meteor defaults and the sliders weren’t very usable. This PR adds explicit slider ranges (and a proper min/max range for y-level) so the UI matches what you’d actually want to set.

* DiscordNotifs: message-delay 0–10000 ms
* ElytraFlyPlusPlus: distance 0–10, y-level -64–320 (range + slider)
* GrimAirPlace: place-delay 0–10 ticks